### PR TITLE
Make command idempotent; add command-line options

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -25,10 +25,12 @@ opam)
   ;;
 esac
   
-git clone git://github.com/avsm/ocaml-github
+git clone git://github.com/mirage/ocaml-github
 cp opam-boot ocaml-github
+OBJ=`pwd`/_obj
+mkdir -p ${OBJ}
 cd ocaml-github
 
-./opam-boot github
-. ./opam-env.sh
+./opam-boot build github --obj ${OBJ}
+. ${OBJ}/opam-env.sh
 which git-jar

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,3 +1,5 @@
+set -x # debug
+
 OCAML_VERSION=4.02.1
 OPAM_VERSION=1.2.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: c
 script: bash -ex .travis-ci.sh
+sudo: required
 env:
   - MODE=cold
   - MODE=ocaml

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ users to compile an application with minimal toolchain requirement.
 To use it, just:
 
 * copy the `opam-boot` script into your own source tree
+* decide where to put the build output. This should be outside the main source tree.
 * add a local `opam` file to describe the project using the [pinning workflow](https://opam.ocaml.org/blog/opam-1-2-pin/)
-* tell users to run `opam-boot <package-name>` to perform a local build.
+* tell users to run `opam-boot build <package-name> --obj <build_dir>` to perform a local build, placing artifacts in <build_dir>.
 
 ## TODO
 

--- a/opam-boot
+++ b/opam-boot
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 # Sensible defaults:
 : ${OPAM_VERSION:="1.2.2"}

--- a/opam-boot
+++ b/opam-boot
@@ -1,43 +1,84 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
-V=1.2.1-beta3
-FILE=opam-full-${V}.tar.gz
-URL=https://github.com/ocaml/opam/releases/download/${V}/${FILE}
+# Sensible defaults:
+: ${OPAM_VERSION:="1.2.2"}
+: ${OCAML_VERSION:="4.02.3"}
+: ${OBJ:=`pwd`/_obj}
 
-OPAM_VERSION=`opam --version 2>/dev/null || true`
-OCAML_VERSION=`ocamlc -version 2>/dev/null || true`
+while [[ $# > 0 ]]; do
+  key="$1"
 
-PKG=$1
+  case $key in
+    --opam)
+    OPAM_VERSION="$2"
+    shift # past argument
+    ;;
+    --ocaml)
+    OCAML_VERSION="$2"
+    shift # past argument
+    ;;
+    --obj)
+    OBJ="$2"
+    shift # past argument
+    ;;
+    build)
+    BUILD="$2"
+    shift # past argument
+    ;;
+    *)
+    echo "Usage: $0 [--opam=$OPAM_VERSION] [--ocaml=$OCAML_VERSION] [--obj=$OBJ] [build <name>]"
+    echo ""
+    echo "Construct an OCaml build environment from scratch with the given version"
+    echo "of OPAM, the given OCaml version and place it in the given obj directory."
+    echo ""
+    echo "If the [build <name>] argument is given then a package is built from an opam"
+    echo "file in the current directory and named <name>."
+    exit 0
+    ;;
+  esac
+  shift
+done
 
-if [ "$PKG" = "" ]; then
-  echo "Usage: $0 <package-name>"
-  echo ""
-  echo "<package-name>: name of the OPAM package being built"
-  exit 1
+ORIGINAL_DIR=`pwd`
+
+mkdir -p ${OBJ}
+ENV=${OBJ}/opam-env.sh
+if [ -e ${ENV} ]; then
+  . ${ENV}
 fi
+echo "export OPAMROOT=\"${OBJ}/opamroot\"" > ${ENV}
+chmod a+x ${ENV}
 
-OBJ=`pwd`/_obj
-ENV=`pwd`/opam-env.sh
-echo "export OPAMROOT=\"`pwd`/.opam\"" > ${ENV}
-chmod a+x opam-env.sh
-if [ "$OPAM_VERSION" = "" ]; then
-  echo OPAM not installed, performing a local installation
-  rm -rf ${OBJ}
-  mkdir -p ${OBJ}
+mkdir -p ${OBJ}
+PATH=${OBJ}/bin:$PATH
+AVAILABLE_OPAM_VERSION=`opam --version 2>/dev/null || true`
+AVAILABLE_OCAML_VERSION=`ocamlc -version 2>/dev/null || true`
+
+FILE=opam-full-${OPAM_VERSION}.tar.gz
+URL=https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${FILE}
+
+if [ "$OPAM_VERSION" = "$AVAILABLE_OPAM_VERSION" ]; then
+  echo OPAM $OPAM_VERSION is already available.
+else
+  echo OPAM $OPAM_VERSION will be installed locally.
   cd ${OBJ}
-  curl -OL ${URL}
+  if [ ! -e ${FILE} ]; then
+    curl -OL ${URL}
+  fi
   tar -zxf ${FILE}
-  cd opam-full-${V}
-  if [ "$OCAML_VERSION" = "" ]; then
-    echo OCaml not installed, performing a local installation
-    make cold CONFIGURE_ARGS="--prefix=${OBJ}"
-  else
+  cd opam-full-${OPAM_VERSION}
+  if [ "" != "$AVAILABLE_OCAML_VERSION" ]; then
+    # TODO: check whether available OCaml is new enough
+    echo OCaml $AVAILABLE_OCAML_VERSION is available to compile OPAM.
     ./configure --prefix=${OBJ}
     make lib-ext
     make
+  else
+    echo OCaml is not available, performing a local installation
+    make cold CONFIGURE_ARGS="--prefix=${OBJ}"
   fi
   make install
-  echo "export PATH=\$PATH:$OBJ/bin" >> ${ENV}
+  echo "export PATH=$OBJ/bin:\$PATH" >> ${ENV}
   cd ${OBJ}/..
 fi
 
@@ -46,16 +87,31 @@ export OPAMJOBS=2
 
 . ${ENV}
 if [ ! -d "${OPAMROOT}" ]; then
-  if [ "$OCAML_VERSION" = "" ]; then
-    opam init -a --comp=4.02.1
-  else
+  if [ "$OCAML_VERSION" = "$AVAILABLE_OCAML_VERSION" ]; then
     opam init -a
+  else
+    opam init -a --comp=$OCAML_VERSION
+  fi
+else
+  if [ "$OCAML_VERSION" != "$AVAILABLE_OCAML_VERSION" ]; then
+    echo Switching to OCaml $OCAML_VERSION
+    opam switch $OCAML_VERSION
   fi
 fi
-
 echo "eval \`opam config env\`" >> ${ENV}
-opam pin add -k git $1 .
+. ${ENV}
 
-echo The $1 package is now built and installed within the .opam directory.
-echo To use it locally, run:
-echo "   . `pwd`/opam-env.sh"
+AVAILABLE_OPAM_VERSION=`opam --version 2>/dev/null || true`
+AVAILABLE_OCAML_VERSION=`ocamlc -version 2>/dev/null || true`
+echo The build environment in ${OBJ} now has:
+echo OPAM version $AVAILABLE_OPAM_VERSION
+echo OCaml verion $AVAILABLE_OCAML_VERSION
+echo To use the new environment, source the file:
+echo ${OBJ}/opam-env.sh
+
+if [ "" != "${BUILD}" ]; then
+  echo Attempting to build ${BUILD} using a local opam file
+  cd ${ORIGINAL_DIR}
+  opam pin add -k git ${BUILD} .
+  opam install ${BUILD} -y
+fi

--- a/opam-boot
+++ b/opam-boot
@@ -79,7 +79,7 @@ else
   fi
   make install
   echo "export PATH=$OBJ/bin:\$PATH" >> ${ENV}
-  cd ${OBJ}/..
+  cd ${OBJ}
 fi
 
 export OPAMYES=1


### PR DESCRIPTION
`opam-boot` is now tolerant of the build directory already existing
(from a previous build attempt) and will try to do the minimum thing to
update the configuration.

`opam-boot` will download external resources unless they have already
been downloaded i.e. the build directory acts as a cache.

Signed-off-by: David Scott dave.scott@unikernel.com
