### PR TITLE
Fix shebang & Ensure `opam init` doesn't update global conf files

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,13 +1,17 @@
 set -x # debug
 
-OCAML_VERSION=4.02.1
-OPAM_VERSION=1.2.1
+# OCaml/OPAM version for selecting the PPA
+OCAML_VERSION=4.02.3
+OPAM_VERSION=1.2.2
+
+# OCaml version for ocaml-github (requires >= 4.03.0)
+G_OCAML_VERSION=4.03.0
 
 case "$OCAML_VERSION,$OPAM_VERSION" in
-4.00.1,1.2.0) ppa=avsm/ocaml40+opam12 ;;
-4.01.0,1.2.0) ppa=avsm/ocaml41+opam12 ;;
-4.02.1,1.2.0) ppa=avsm/ocaml42+opam12 ;;
-4.02.1,1.2.1) ppa=avsm/ppa-opam-experimental ;;
+4.00.1,1.2.1) ppa=avsm/ocaml40+opam12 ;;
+4.01.0,1.2.1) ppa=avsm/ocaml41+opam12 ;;
+4.02.3,1.2.2) ppa=avsm/ocaml42+opam12 ;;
+# 4.02.3,1.2.2) ppa=avsm/ppa-opam-experimental ;;
 *) echo Unknown $OCAML_VERSION,$OPAM_VERSION; exit 1 ;;
 esac
 
@@ -33,6 +37,6 @@ OBJ=`pwd`/_obj
 mkdir -p ${OBJ}
 cd ocaml-github
 
-./opam-boot build github --obj ${OBJ}
+./opam-boot --ocaml "$G_OCAML_VERSION" build github-unix --obj ${OBJ}
 . ${OBJ}/opam-env.sh
 which git-jar

--- a/opam-boot
+++ b/opam-boot
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+set -e
 
 # Sensible defaults:
 : ${OPAM_VERSION:="1.2.2"}

--- a/opam-boot
+++ b/opam-boot
@@ -89,9 +89,9 @@ export OPAMJOBS=2
 . ${ENV}
 if [ ! -d "${OPAMROOT}" ]; then
   if [ "$OCAML_VERSION" = "$AVAILABLE_OCAML_VERSION" ]; then
-    opam init -a
+    opam init -n
   else
-    opam init -a --comp=$OCAML_VERSION
+    opam init -n --comp=$OCAML_VERSION
   fi
 else
   if [ "$OCAML_VERSION" != "$AVAILABLE_OCAML_VERSION" ]; then

--- a/opam-boot
+++ b/opam-boot
@@ -27,7 +27,7 @@ while [[ $# > 0 ]]; do
     shift # past argument
     ;;
     *)
-    echo "Usage: $0 [--opam=$OPAM_VERSION] [--ocaml=$OCAML_VERSION] [--obj=$OBJ] [build <name>]"
+    echo "Usage: $0 [--opam $OPAM_VERSION] [--ocaml $OCAML_VERSION] [--obj $OBJ] [build <name>]"
     echo ""
     echo "Construct an OCaml build environment from scratch with the given version"
     echo "of OPAM, the given OCaml version and place it in the given obj directory."


### PR DESCRIPTION
Hi @avsm,

I recently wrote a simple [script](https://github.com/erikmd/install-tuareg-pfita) based on `opam-boot` (to help our students install Merlin for the lab sessions of our functional programming course).

While one can workaround issue #3 by prepending `bash` before `opam-boot`, issue #1 is more problematic.

So I'd like to propose this PR that addresses #1 and #3 (along with a minor detail regarding the doc).

Kind regards.