### PR TITLE
Make opam-boot more robust thanks to shellcheck

### DIFF
--- a/opam-boot
+++ b/opam-boot
@@ -4,12 +4,12 @@ set -e
 # Sensible defaults:
 : ${OPAM_VERSION:="1.2.2"}
 : ${OCAML_VERSION:="4.02.3"}
-: ${OBJ:=`pwd`/_obj}
+: ${OBJ:="$(pwd)/_obj"}
 
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
   key="$1"
 
-  case $key in
+  case "$key" in
     --opam)
     OPAM_VERSION="$2"
     shift # past argument
@@ -40,38 +40,38 @@ while [[ $# > 0 ]]; do
   shift
 done
 
-ORIGINAL_DIR=`pwd`
+ORIGINAL_DIR=$(pwd)
 
-mkdir -p ${OBJ}
-ENV=${OBJ}/opam-env.sh
-if [ -e ${ENV} ]; then
-  . ${ENV}
+mkdir -p "${OBJ}"
+ENV="${OBJ}/opam-env.sh"
+if [ -e "${ENV}" ]; then
+  . "${ENV}"
 fi
-echo "export OPAMROOT=\"${OBJ}/opamroot\"" > ${ENV}
-chmod a+x ${ENV}
+echo "export OPAMROOT=\"${OBJ}/opamroot\"" > "${ENV}"
+chmod a+x "${ENV}"
 
-mkdir -p ${OBJ}
-PATH=${OBJ}/bin:$PATH
-AVAILABLE_OPAM_VERSION=`opam --version 2>/dev/null || true`
-AVAILABLE_OCAML_VERSION=`ocamlc -version 2>/dev/null || true`
+mkdir -p "${OBJ}"
+PATH="${OBJ}/bin:$PATH"
+AVAILABLE_OPAM_VERSION=$(opam --version 2>/dev/null || true)
+AVAILABLE_OCAML_VERSION=$(ocamlc -version 2>/dev/null || true)
 
-FILE=opam-full-${OPAM_VERSION}.tar.gz
-URL=https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${FILE}
+FILE="opam-full-${OPAM_VERSION}.tar.gz"
+URL="https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${FILE}"
 
 if [ "$OPAM_VERSION" = "$AVAILABLE_OPAM_VERSION" ]; then
-  echo OPAM $OPAM_VERSION is already available.
+  echo OPAM "$OPAM_VERSION" is already available.
 else
-  echo OPAM $OPAM_VERSION will be installed locally.
-  cd ${OBJ}
-  if [ ! -e ${FILE} ]; then
-    curl -OL ${URL}
+  echo OPAM "$OPAM_VERSION" will be installed locally.
+  cd "${OBJ}"
+  if [ ! -e "${FILE}" ]; then
+    curl -OL "${URL}"
   fi
-  tar -zxf ${FILE}
-  cd opam-full-${OPAM_VERSION}
+  tar -zxf "${FILE}"
+  cd "opam-full-${OPAM_VERSION}"
   if [ "" != "$AVAILABLE_OCAML_VERSION" ]; then
     # TODO: check whether available OCaml is new enough
-    echo OCaml $AVAILABLE_OCAML_VERSION is available to compile OPAM.
-    ./configure --prefix=${OBJ}
+    echo OCaml "$AVAILABLE_OCAML_VERSION" is available to compile OPAM.
+    ./configure "--prefix=${OBJ}"
     make lib-ext
     make
   else
@@ -79,40 +79,40 @@ else
     make cold CONFIGURE_ARGS="--prefix=${OBJ}"
   fi
   make install
-  echo "export PATH=$OBJ/bin:\$PATH" >> ${ENV}
-  cd ${OBJ}
+  echo "export PATH=\"$OBJ/bin:\$PATH\"" >> "${ENV}"
+  cd "${OBJ}"
 fi
 
 export OPAMYES=1
 export OPAMJOBS=2
 
-. ${ENV}
+. "${ENV}"
 if [ ! -d "${OPAMROOT}" ]; then
   if [ "$OCAML_VERSION" = "$AVAILABLE_OCAML_VERSION" ]; then
     opam init -n
   else
-    opam init -n --comp=$OCAML_VERSION
+    opam init -n "--comp=$OCAML_VERSION"
   fi
 else
   if [ "$OCAML_VERSION" != "$AVAILABLE_OCAML_VERSION" ]; then
-    echo Switching to OCaml $OCAML_VERSION
-    opam switch $OCAML_VERSION
+    echo Switching to OCaml "$OCAML_VERSION"
+    opam switch "$OCAML_VERSION"
   fi
 fi
-echo "eval \`opam config env\`" >> ${ENV}
-. ${ENV}
+echo "eval \`opam config env\`" >> "${ENV}"
+. "${ENV}"
 
-AVAILABLE_OPAM_VERSION=`opam --version 2>/dev/null || true`
-AVAILABLE_OCAML_VERSION=`ocamlc -version 2>/dev/null || true`
-echo The build environment in ${OBJ} now has:
-echo OPAM version $AVAILABLE_OPAM_VERSION
-echo OCaml verion $AVAILABLE_OCAML_VERSION
+AVAILABLE_OPAM_VERSION=$(opam --version 2>/dev/null || true)
+AVAILABLE_OCAML_VERSION=$(ocamlc -version 2>/dev/null || true)
+echo The build environment in "${OBJ}" now has:
+echo OPAM version "$AVAILABLE_OPAM_VERSION"
+echo OCaml verion "$AVAILABLE_OCAML_VERSION"
 echo To use the new environment, source the file:
-echo ${OBJ}/opam-env.sh
+echo "${OBJ}/opam-env.sh"
 
 if [ "" != "${BUILD}" ]; then
-  echo Attempting to build ${BUILD} using a local opam file
-  cd ${ORIGINAL_DIR}
-  opam pin add -k git ${BUILD} .
-  opam install ${BUILD} -y
+  echo Attempting to build "${BUILD}" using a local opam file
+  cd "${ORIGINAL_DIR}"
+  opam pin add -k git "${BUILD}" .
+  opam install "${BUILD}" -y
 fi


### PR DESCRIPTION
Hi @avsm,
one of my students reported me a bug related to `opam-boot`, namely some quotes were missing at
https://github.com/avsm/opam-boot/blob/2ca61945e18cd45d01c1c168e128260cedb04c65/opam-boot#L45
I took this opportunity to run `shellcheck` on `opam-boot` and this PR takes into account its feedback.
Kind regards, Erik